### PR TITLE
Store everything as a string

### DIFF
--- a/scraperwiki.php
+++ b/scraperwiki.php
@@ -61,6 +61,8 @@ static function	save_sqlite($unique_keys = array(), $data, $table_name='swdata')
 	// prepare an insert if we don't need to update
     foreach ($data as $key => $value) {
     	$table->$key = $value;
+      // Don't do anything clever. Just always store everything as a string
+      $table->setMeta('cast.'.$key, 'string');
     }
 
     // If this is the first row ever added, use this to create table and exit


### PR DESCRIPTION
Before this patch if you save some data with an iso formatted string to a new table (this is crucial) it will create the table schema with a trait of numeric for the date.

This is different behaviour than scraperwiki classic which would create that same iso date field as a string.

This patch does the simple thing and just forces all the fields to be written as strings.
